### PR TITLE
Switch to centos:8 base images

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,7 @@
 FROM quay.io/ansible/ansible-runner:devel
 
 RUN pip3 install --upgrade pip setuptools
+RUN dnf config-manager --set-enabled epel
 ADD requirements.yml /build/
 
 RUN ansible-galaxy role install -r /build/requirements.yml --roles-path /usr/share/ansible/roles

--- a/bindep_combined.txt
+++ b/bindep_combined.txt
@@ -9,6 +9,7 @@ python3-pycurl [platform:rpm]  # from collection ovirt.ovirt
 python3-netaddr [platform:rpm]  # from collection ovirt.ovirt
 python3-jmespath [platform:rpm]  # from collection ovirt.ovirt
 python3-passlib [platform:rpm]  # from collection ovirt.ovirt
+gcc-c++ [platform:rpm]  # from collection user
 python3-devel [platform:rpm]  # from collection user
 subversion [platform:rpm]  # from collection user
 subversion [platform:dpkg]  # from collection user

--- a/bindep_output.txt
+++ b/bindep_output.txt
@@ -1,4 +1,4 @@
-kubernetes-client
+gcc-c++
 libxml2-devel
 python3-devel
 python3-jmespath

--- a/execution-environment.yml
+++ b/execution-environment.yml
@@ -6,3 +6,4 @@ dependencies:
 additional_build_steps:
   prepend:
     - RUN pip3 install --upgrade pip setuptools
+    - RUN dnf config-manager --set-enabled epel

--- a/requirements/bindep_requirements.txt
+++ b/requirements/bindep_requirements.txt
@@ -1,3 +1,4 @@
+gcc-c++ [platform:rpm]
 python3-devel [platform:rpm]
 subversion [platform:rpm]
 subversion [platform:dpkg]


### PR DESCRIPTION
This update change our execution environment to centos:8. The main
change, is the removal of kubernetes-client. This doesn't exist as an
RPM right now in centos.

We also have to enable EPEL to pull in a few packages, needed by
collections. A future update may filter this to only be enabled for the
specific packages we need in EPEL.

Depends-On: https://github.com/ansible/ansible-runner/pull/581
Signed-off-by: Paul Belanger <pabelanger@redhat.com>