### PR TITLE
Rename LICENSE.md to LICENSE

### DIFF
--- a/bindep_combined.txt
+++ b/bindep_combined.txt
@@ -13,7 +13,7 @@ python3-netaddr [platform:rpm]  # from collection ovirt.ovirt
 python3-jmespath [platform:rpm]  # from collection ovirt.ovirt
 python3-passlib [platform:rpm epel]  # from collection ovirt.ovirt
 qemu-img [platform:rpm]  # from collection ovirt.ovirt
-python3-devel [platform:rpm compile]  # from collection user
+python38-devel [platform:rpm compile]  # from collection user
 subversion [platform:rpm]  # from collection user
 subversion [platform:dpkg]  # from collection user
 glibc-langpack-en [platform:rpm]  # from collection user

--- a/tools/bindep.txt
+++ b/tools/bindep.txt
@@ -1,4 +1,4 @@
-python3-devel [platform:rpm compile]
+python38-devel [platform:rpm compile]
 subversion [platform:rpm]
 subversion [platform:dpkg]
 glibc-langpack-en [platform:rpm]


### PR DESCRIPTION
Use the standard 'text' format of the apache2 license file.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>