### PR TITLE
Switch to python3.8 for awx-ee

### DIFF
--- a/.zuul.d/jobs.yaml
+++ b/.zuul.d/jobs.yaml
@@ -11,6 +11,7 @@
     parent: tox
     requires:
       - ansible-runner-container-image
+      - python-builder-container-image
     required-projects:
       - github.com/ansible/ansible-builder
     nodeset: ubuntu-bionic-1vcpu
@@ -24,7 +25,9 @@
     description: Build awx-ee container image
     timeout: 2700
     provides: awx-ee-container-image
-    requires: ansible-runner-container-image
+    requires:
+      - ansible-runner-container-image
+      - python-builder-container-image
     vars: &vars
       container_images: &container_images
         - context: .
@@ -42,5 +45,7 @@
     description: Build awx-ee container image and upload to quay.io
     timeout: 2700
     provides: awx-ee-container-image
-    requires: ansible-runner-container-image
+    requires:
+      - ansible-runner-container-image
+      - python-builder-container-image
     vars: *vars

--- a/bindep_combined.txt
+++ b/bindep_combined.txt
@@ -13,7 +13,7 @@ python3-netaddr [platform:rpm]  # from collection ovirt.ovirt
 python3-jmespath [platform:rpm]  # from collection ovirt.ovirt
 python3-passlib [platform:rpm epel]  # from collection ovirt.ovirt
 qemu-img [platform:rpm]  # from collection ovirt.ovirt
-python3-devel [platform:rpm compile]  # from collection user
+python38-devel [platform:rpm compile]  # from collection user
 subversion [platform:rpm]  # from collection user
 subversion [platform:dpkg]  # from collection user
 glibc-langpack-en [platform:rpm]  # from collection user

--- a/tools/bindep.txt
+++ b/tools/bindep.txt
@@ -1,4 +1,4 @@
-python3-devel [platform:rpm compile]
+python38-devel [platform:rpm compile]
 subversion [platform:rpm]
 subversion [platform:dpkg]
 glibc-langpack-en [platform:rpm]


### PR DESCRIPTION
This rebuilds the awx-ee container image, using python3.8 as the base
version of python.

Depends-On: https://github.com/ansible/ansible-runner/pull/594
Signed-off-by: Paul Belanger <pabelanger@redhat.com>