### PR TITLE
Revert "Add glibc-langpack-en"

### DIFF
--- a/bindep_combined.txt
+++ b/bindep_combined.txt
@@ -16,4 +16,3 @@ qemu-img [platform:rpm]  # from collection ovirt.ovirt
 python3-devel [platform:rpm compile]  # from collection user
 subversion [platform:rpm]  # from collection user
 subversion [platform:dpkg]  # from collection user
-glibc-langpack-en [platform:rpm]  # from collection user

--- a/tools/bindep.txt
+++ b/tools/bindep.txt
@@ -1,4 +1,3 @@
 python3-devel [platform:rpm compile]
 subversion [platform:rpm]
 subversion [platform:dpkg]
-glibc-langpack-en [platform:rpm]


### PR DESCRIPTION
We've actually promoted this into ansible-runner, given ansible-test
requires it.

This reverts commit 560436a8751ae9cb6018f53b0ded7144c3abf5f3.

Depends-On: https://github.com/ansible/ansible-runner/pull/593
Signed-off-by: Paul Belanger <pabelanger@redhat.com>