### PR TITLE
Use released version of community.kubernetes

### DIFF
--- a/_build/requirements.yml
+++ b/_build/requirements.yml
@@ -14,8 +14,7 @@ collections:
   - name: community.vmware  # has requirements.txt, but may add pyvcloud
   - name: https://github.com/shanemcd/ovirt-ansible-collection
     type: git
-  - name: https://github.com/ansible-collections/community.kubernetes.git
-    type: git
+  - name: community.kubernetes
   # adds openshift python lib
   # needs kubectl for yum / dnf / apt-get
   # needs to install snap, then use snap to install helm


### PR DESCRIPTION
I don't see any reason we need the development version of this.