### PR TITLE
Add ansible-navigator-demo-ee tag

### DIFF
--- a/.zuul.d/jobs.yaml
+++ b/.zuul.d/jobs.yaml
@@ -37,6 +37,11 @@
             # If zuul.tag is defined: [ '3', '3.19', '3.19.0' ].  Only works for 3-component tags.
             # Otherwise: ['devel']
             &imagetag "{{ zuul.tag is defined | ternary([zuul.get('tag', '').split('.')[0], '.'.join(zuul.get('tag', '').split('.')[:2]), zuul.get('tag', '')], ['devel']) }}"
+        - context: tools/ansible-navigator-demo-ee
+          registry: quay.io
+          repository: quay.io/ansible/ansible-navigator-demo-ee
+          tags:
+            ['latest']
       docker_images: *container_images
 
 - job:

--- a/tools/ansible-navigator-demo-ee/Dockerfile
+++ b/tools/ansible-navigator-demo-ee/Dockerfile
@@ -1,0 +1,1 @@
+FROM quay.io/ansible/awx-ee:devel


### PR DESCRIPTION
We want to also publish the awx-ee image, as the navigator demo image.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>