### PR TITLE
Pinning ansible-runner base image until devel is released

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -1,4 +1,4 @@
-ARG EE_BASE_IMAGE=quay.io/ansible/ansible-runner:latest
+ARG EE_BASE_IMAGE=quay.io/ansible/ansible-runner:stable-2.12-devel
 ARG EE_BUILDER_IMAGE=quay.io/ansible/ansible-builder:latest
 
 FROM $EE_BASE_IMAGE as galaxy

--- a/execution-environment.yml
+++ b/execution-environment.yml
@@ -1,5 +1,7 @@
 ---
 version: 1
+build_arg_defaults:
+  EE_BASE_IMAGE: 'quay.io/ansible/ansible-runner:stable-2.12-devel'
 dependencies:
   galaxy: _build/requirements.yml
   system: _build/bindep.txt


### PR DESCRIPTION
We want to get the `--omit-env-files` and associated changes from ansible-runner but they are only available in a pinned version of the container. This can be reverted once those changes are in the latest container.