### PR TITLE
Add requirements.txt to Containerfile

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -16,7 +16,8 @@ FROM $EE_BUILDER_IMAGE as builder
 COPY --from=galaxy /usr/share/ansible /usr/share/ansible
 
 ADD _build/bindep.txt bindep.txt
-RUN ansible-builder introspect --sanitize --user-bindep=bindep.txt --write-bindep=/tmp/src/bindep.txt --write-pip=/tmp/src/requirements.txt
+ADD requirements.txt requirements.txt
+RUN ansible-builder introspect --sanitize --user-bindep=bindep.txt --user-pip=requirements.txt --write-bindep=/tmp/src/bindep.txt --write-pip=/tmp/src/requirements.txt
 RUN assemble
 
 FROM $EE_BASE_IMAGE


### PR DESCRIPTION
Originally I was trying to install [JMESPath](https://jmespath.org/) by adding the following value to the __build/bindep.txt_ file:
`python3-jmespath [platform:rpm]`
But it didn't work, JMESPath was still not recognized in my playbook. I solved the issue by installing JMESPath via pip instead of rpm.
This pull request allows to use the _requirements.txt_ file to define Python packages to include during the build of the Docker image.