### PR TITLE
Reverting temp commit #104

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -1,4 +1,4 @@
-ARG EE_BASE_IMAGE=quay.io/ansible/ansible-runner:stable-2.12-devel
+ARG EE_BASE_IMAGE=quay.io/ansible/ansible-runner:latest
 ARG EE_BUILDER_IMAGE=quay.io/ansible/ansible-builder:latest
 
 FROM $EE_BASE_IMAGE as galaxy

--- a/execution-environment.yml
+++ b/execution-environment.yml
@@ -1,7 +1,7 @@
 ---
 version: 1
 build_arg_defaults:
-  EE_BASE_IMAGE: 'quay.io/ansible/ansible-runner:stable-2.12-devel'
+  EE_BASE_IMAGE: 'quay.io/ansible/ansible-runner:latest'
 dependencies:
   galaxy: _build/requirements.yml
   system: _build/bindep.txt


### PR DESCRIPTION
Testing has completed and the required change was released as ansible-runner 2.1.3.
Changing pinned version of runner back to latest.
This reverts https://github.com/ansible/awx-ee/pull/104