### PR TITLE
Pin pyOpenSSL lower bound

### DIFF
--- a/_build/requirements.txt
+++ b/_build/requirements.txt
@@ -1,1 +1,2 @@
 git+https://github.com/ansible/ansible-sign
+pyOpenSSL>=20


### PR DESCRIPTION
Possible fix for #134.

Another possible solution is to put an upper bound on cryptography, but that seems like a less ideal solution. Curious what others think.

Signed-off-by: Rick Elrod <rick@elrod.me>