### PR TITLE
Fix image build (remove pinned cryptography, upgrade ansible-runner)

### DIFF
--- a/_build/requirements.txt
+++ b/_build/requirements.txt
@@ -1,2 +1,2 @@
 git+https://github.com/ansible/ansible-sign
-cryptography==37.0.4
+ansible-runner>=2.2.1


### PR DESCRIPTION
I initially tried just removing the pinned cryptography version, but then ran into https://github.com/ansible/ansible-runner/issues/1138. Forcing runner to upgrade resolved it. 

I tested this with a project update that downloads a collection to make sure we didn't reintroduce https://github.com/ansible/awx-ee/issues/134:

<img width="913" alt="image" src="https://user-images.githubusercontent.com/773186/194185775-de332e7f-f18d-42fb-b752-b2cd1723fa5e.png">
