### PR TITLE
Pin `community.vmware` to 2.x branch

### DIFF
--- a/_build/requirements.yml
+++ b/_build/requirements.yml
@@ -7,6 +7,7 @@ collections:
   - name: google.cloud
   - name: openstack.cloud
   - name: community.vmware
+    version: '>=2.0.0,<3.0.0' # Pin to 2.x until ansible-runner is on 2.13+
   - name: ovirt.ovirt
   - name: kubernetes.core
   - name: ansible.posix


### PR DESCRIPTION
Per the `community.vmware` changelog. Ansible-core 2.12 has been deprecated with collection release `3.0.0`. https://github.com/ansible-collections/community.vmware/blob/main/CHANGELOG.rst#breaking-changes-porting-guide 

AWX-EE currently uses `ansible-runner` 2.12.
This will pin the version to the latest 2.x release, which maintains support for Ansible 2.12.