### PR TITLE
tox 4: whitelist -> allowlist, and allow bash

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -10,8 +10,8 @@ deps = -r{toxinidir}/requirements.txt
 [testenv:podman]
 passenv =
   HOME
-whitelist_external =
-  true
+allowlist_externals =
+  /bin/bash
 commands =
   /bin/bash -c "podman rmi quay.io/ansible/awx-ee:latest || true"
   ansible-builder build -v3 -c . -t quay.io/ansible/awx-ee {posargs}
@@ -20,15 +20,18 @@ commands =
 [testenv:docker]
 passenv =
   HOME DOCKER_BUILDKIT
-whitelist_external =
-  true
+allowlist_externals =
+  /bin/bash
 commands =
-  /bin/bash -c "podman rmi quay.io/ansible/awx-ee:latest || true"
+  /bin/bash -c "docker rmi quay.io/ansible/awx-ee:latest || true"
   ansible-builder build -v3 -c . -t quay.io/ansible/awx-ee {posargs} --container-runtime=docker
 
 [testenv:check-diff]
 passenv =
   {[testenv:docker]passenv}
+allowlist_externals =
+  /bin/bash
+  {toxinidir}/tools/check_ansible_builder_changed.sh
 commands =
   {[testenv:docker]commands}
   {toxinidir}/tools/check_ansible_builder_changed.sh


### PR DESCRIPTION
Also fix that we were deleting the podman image instead of the docker image at the start of `tox -e docker`

Signed-off-by: Rick Elrod <rick@elrod.me>