### PR TITLE
Update config for breaking change in Tox 4.0.6

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -8,8 +8,7 @@ install_command = pip install {opts} {packages}
 deps = -r{toxinidir}/requirements.txt
 
 [testenv:podman]
-passenv =
-  HOME
+passenv = HOME
 allowlist_externals =
   /bin/bash
 commands =
@@ -18,8 +17,7 @@ commands =
 
 
 [testenv:docker]
-passenv =
-  HOME DOCKER_BUILDKIT
+passenv = HOME,DOCKER_BUILDKIT
 allowlist_externals =
   /bin/bash
 commands =
@@ -27,8 +25,7 @@ commands =
   ansible-builder build -v3 -c . -t quay.io/ansible/awx-ee {posargs} --container-runtime=docker
 
 [testenv:check-diff]
-passenv =
-  {[testenv:docker]passenv}
+passenv = {[testenv:docker]passenv}
 allowlist_externals =
   /bin/bash
   {toxinidir}/tools/check_ansible_builder_changed.sh


### PR DESCRIPTION
https://github.com/tox-dev/tox/issues/2676 for details.

Also https://github.com/tox-dev/tox/issues/2658 and https://github.com/tox-dev/tox/pull/2671

Signed-off-by: Rick Elrod <rick@elrod.me>

Effectively, Tox 4 changed this syntax (with no deprecation warning, no docs update other than an FAQ question). Tox 4.0.0 - 4.0.5 silently ate the error which is why we didn't see it, and 4.0.6 suddenly made it a fatal. :grimacing: