### PR TITLE
#161 fix ovirt.ovirt galaxy module and add sshpass via dnf (untested)

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -21,7 +21,7 @@ FROM $EE_BUILDER_IMAGE as builder
 COPY --from=galaxy /usr/share/ansible /usr/share/ansible
 
 # BEGIN (remove this when we move back to using ansible-builder)
-RUN dnf install -y python3.9-pip && pip3 install -U pip && pip3 install ansible-builder wheel
+RUN dnf install -y python3.9-pip sshpass && pip3 install -U pip && pip3 install ansible-builder wheel
 # END (remove this when we move back to using ansible-builder)
 
 ADD _build/requirements.txt requirements.txt

--- a/_build/requirements.yml
+++ b/_build/requirements.yml
@@ -7,9 +7,7 @@ collections:
   - name: google.cloud
   - name: openstack.cloud
   - name: community.vmware
-  - name: https://github.com/oVirt/ovirt-ansible-collection.git
-    type: git
-    version: master
+  - name: ovirt.ovirt
   - name: kubernetes.core
   - name: ansible.posix
   - name: ansible.windows


### PR DESCRIPTION
This looks like it could fix #161 ... but I was not able to test it.

Also I do not know if this fixes everything that is different between ansible/ansible-runner:latest and centos/centos:stream9 as introduced in 4cfa302bbcaaec60009692976c7022f49839418b

Feel free to close this, if you do not want/need it.