### PR TITLE
Install missing dependencies

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -62,8 +62,6 @@ RUN dnf install -y python3.9-pip && pip3 install -U pip
 
 RUN install-from-bindep && rm -rf /output/wheels
 
-RUN pip install dumb-init ansible-core
-
 # In OpenShift, container will run as a random uid number and gid 0. Make sure things
 # are writeable by the root group.
 RUN for dir in \

--- a/_build/requirements.txt
+++ b/_build/requirements.txt
@@ -1,2 +1,16 @@
 git+https://github.com/ansible/ansible-sign
 ansible-runner>=2.3.1
+
+ansible-core
+dumb-init
+
+ncclient
+paramiko
+pyOpenSSL
+pypsrp[kerberos,credssp]
+pywinrm[kerberos,credssp]
+toml
+pexpect>=4.5
+python-daemon
+pyyaml
+six

--- a/_build/requirements.yml
+++ b/_build/requirements.yml
@@ -9,7 +9,7 @@ collections:
   - name: https://github.com/relrod/community.vmware.git
     type: git
     version: pin-vsphere-automation-sdk-python
-  - name: https://github.com/oVirt/ovirt-ansible-collection.git
+  - name: https://github.com/shanemcd/ovirt-ansible-collection.git
     type: git
     version: master
   - name: kubernetes.core

--- a/_build/requirements.yml
+++ b/_build/requirements.yml
@@ -6,7 +6,9 @@ collections:
   - name: theforeman.foreman
   - name: google.cloud
   - name: openstack.cloud
-  - name: community.vmware
+  - name: https://github.com/relrod/community.vmware.git
+    type: git
+    version: pin-vsphere-automation-sdk-python
   - name: https://github.com/oVirt/ovirt-ansible-collection.git
     type: git
     version: master


### PR DESCRIPTION
This adds a few dependencies based on the old ansible-runner image that we forgot to pull into the CentOS Stream 9 image.

Fixes ansible/awx#13510
Fixes #161
Fixes ansible/awx#13511
Fixes ansible/awx-operator#1214
Fixes #163
Fixes #164 
Closes #162 