### PR TITLE
adding community.hashi_vault

### DIFF
--- a/_build/requirements.yml
+++ b/_build/requirements.yml
@@ -16,3 +16,4 @@ collections:
   - name: ansible.posix
   - name: ansible.windows
   - name: redhatinsights.insights
+  - name: community.hashi_vault


### PR DESCRIPTION
Pull request to satisfy issue  #184    Adds community.hashi_vault to requirements.yml which automatically installs the hvac dependency.  