### PR TITLE
Bump ansible-runner minimum version

### DIFF
--- a/_build/requirements.txt
+++ b/_build/requirements.txt
@@ -1,5 +1,5 @@
 git+https://github.com/ansible/ansible-sign
-ansible-runner>=2.3.1
+ansible-runner>=2.3.2
 
 ansible-core
 dumb-init


### PR DESCRIPTION
As I merge https://github.com/ansible/awx/pull/13608, it is expected that AWX users should be able to use this.