### PR TITLE
Alternatives: SymLink `python` -> `python3`

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -62,6 +62,9 @@ RUN dnf install -y python3.9-pip && pip3 install -U pip
 
 RUN install-from-bindep && rm -rf /output/wheels
 
+# python -> python3 SymLink (as in Automation Platform EEs)
+RUN alternatives --install /usr/bin/python python /usr/bin/python3.9 209
+
 # In OpenShift, container will run as a random uid number and gid 0. Make sure things
 # are writeable by the root group.
 RUN for dir in \


### PR DESCRIPTION
Adds SymLink from `/usr/bin/python` to `/usr/bin/python3` via Alternatives.

This mirrors behavior in official Ansible Automation Platform EEs and resolves #168 

```
% docker run -it registry.redhat.io/ansible-automation-platform-23/ee-supported-rhel8:latest bash

# bash-4.4# alternatives --display python
python - status is manual.
 link currently points to /usr/bin/python3.9
...
```

Tested and working in my private AWX-EE fork.