### PR TITLE
Pin Ansible core to devel until 2.15 comes out

### DIFF
--- a/_build/requirements.txt
+++ b/_build/requirements.txt
@@ -1,7 +1,7 @@
 git+https://github.com/ansible/ansible-sign
 ansible-runner>=2.3.1
 
-ansible-core
+git+https://github.com/ansible/ansible.git
 dumb-init
 
 ncclient


### PR DESCRIPTION
This is to support https://github.com/ansible/awx/pull/13448, which requires `--limit` added to `ansible-inventory` in order to fully function.