### PR TITLE
Backport ansible-inventory --limit feature

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -62,6 +62,10 @@ RUN dnf install -y python3.9-pip && pip3 install -U pip
 
 RUN install-from-bindep && rm -rf /output/wheels
 
+ADD https://raw.githubusercontent.com/ansible/ansible/ff3ee9c4bdac68909bcb769091a198a7c45e6350/lib/ansible/cli/inventory.py \
+      /usr/local/lib/python3.9/site-packages/ansible/cli/inventory.py
+RUN chmod 0644 /usr/local/lib/python3.9/site-packages/ansible/cli/inventory.py
+
 # In OpenShift, container will run as a random uid number and gid 0. Make sure things
 # are writeable by the root group.
 RUN for dir in \

--- a/_build/requirements.txt
+++ b/_build/requirements.txt
@@ -1,7 +1,11 @@
 git+https://github.com/ansible/ansible-sign
 ansible-runner>=2.3.1
 
-ansible-core
+# We are carrying a backport into 2.14. We pin to <2.15 so we don't break
+# builds as soon as 2.15 drops. We should drop our backport and remove this pin
+# once 2.15 comes out.
+ansible-core<2.15
+
 dumb-init
 
 ncclient


### PR DESCRIPTION
The limit feature to ansible-inventory has landed in ansible-core devel to make it into 2.15. This temporarily backports this feature into our EE that uses 2.14, so that constructed inventory work can make use of it.