### PR TITLE
Use Galaxy ovirt.ovirt to fix namespace error

### DIFF
--- a/_build/requirements.yml
+++ b/_build/requirements.yml
@@ -9,9 +9,7 @@ collections:
   - name: https://github.com/relrod/community.vmware.git
     type: git
     version: pin-vsphere-automation-sdk-python
-  - name: https://github.com/shanemcd/ovirt-ansible-collection.git
-    type: git
-    version: master
+  - name: ovirt.ovirt
   - name: kubernetes.core
   - name: ansible.posix
   - name: ansible.windows


### PR DESCRIPTION
The reason we used a git source for this collection is to get this patch:

https://github.com/oVirt/ovirt-ansible-collection/pull/657

But that patch is now out, first tag was [3.1.0-1](https://github.com/oVirt/ovirt-ansible-collection/releases/tag/3.1.0-1) and now 3.1.2 is out on Galaxy.

https://galaxy.ansible.com/ovirt/ovirt

But even more importantly here, the git requirement never worked. In current image:

```
bash-5.1$ ansible-galaxy collection list

# /usr/share/ansible/collections/ansible_collections
Collection              Version
----------------------- -------
@NAMESPACE@.@NAME@      3.0.1  
amazon.aws              5.4.0  
ansible.posix           1.5.2  
ansible.windows         1.13.0 
awx.awx                 22.0.0 
azure.azcollection      1.15.0 
community.vmware        *      
google.cloud            1.1.3  
kubernetes.core         2.4.0  
openstack.cloud         2.0.0  
redhatinsights.insights 1.0.7  
theforeman.foreman      3.10.0 
```

So this should fix that, although it reveals that we're missing any type of coverage to catch this kind of thing.