### PR TITLE
Switch to ansible-core rc 2.15

### DIFF
--- a/execution-environment.yml
+++ b/execution-environment.yml
@@ -5,10 +5,8 @@ images:
     name: quay.io/centos/centos:stream9
 dependencies:
   ansible_core:
-    # We are carrying a backport into 2.14. We pin to <2.15 so we don't break
-    # builds as soon as 2.15 drops. We should drop our backport and remove this pin
-    # once 2.15 comes out.
-    package_pip: ansible-core<2.15
+    # Require minimum of 2.15 to get ansible-inventory --limit option
+    package_pip: ansible-core>=2.15.0rc2,<2.16
   ansible_runner:
     package_pip: ansible-runner
   galaxy: |
@@ -58,6 +56,4 @@ additional_build_steps:
   append_final:
     - COPY --from=quay.io/ansible/receptor:devel /usr/bin/receptor /usr/bin/receptor
     - RUN mkdir -p /var/run/receptor
-    - ADD https://raw.githubusercontent.com/ansible/ansible/ff3ee9c4bdac68909bcb769091a198a7c45e6350/lib/ansible/cli/inventory.py /usr/local/lib/python3.9/site-packages/ansible/cli/inventory.py
-    - RUN chmod 0644 /usr/local/lib/python3.9/site-packages/ansible/cli/inventory.py
     - RUN git lfs install --system


### PR DESCRIPTION
We said before we would switch over when 2.15 release candidates are out.

However, this still may be unworkable if the `--pre` option has unforeseen consequences, like installing release candidates of other libraries?