### PR TITLE
Update `python_interpreter` to 3.11

### DIFF
--- a/execution-environment.yml
+++ b/execution-environment.yml
@@ -4,6 +4,9 @@ images:
   base_image:
     name: quay.io/centos/centos:stream9
 dependencies:
+  python_interpreter:
+    package_system: python3.11
+    python_path: /usr/bin/python3.11
   ansible_core:
     # Require minimum of 2.15 to get ansible-inventory --limit option
     package_pip: ansible-core>=2.15.0rc2,<2.16
@@ -26,7 +29,7 @@ dependencies:
       - name: redhatinsights.insights
   system: |
     git-core [platform:rpm]
-    python3.9-devel [platform:rpm compile]
+    python3.11-devel [platform:rpm compile]
     libcurl-devel [platform:rpm compile]
     krb5-devel [platform:rpm compile]
     krb5-workstation [platform:rpm]
@@ -36,7 +39,6 @@ dependencies:
     sshpass [platform:rpm]
     rsync [platform:rpm]
     epel-release [platform:rpm]
-    python-unversioned-command [platform:rpm]
   python: |
     git+https://github.com/ansible/ansible-sign
     ncclient
@@ -57,3 +59,5 @@ additional_build_steps:
     - COPY --from=quay.io/ansible/receptor:devel /usr/bin/receptor /usr/bin/receptor
     - RUN mkdir -p /var/run/receptor
     - RUN git lfs install --system
+    # SymLink `python` -> `python3.11`
+    - RUN alternatives --install /usr/bin/python python /usr/bin/python3.11 311


### PR DESCRIPTION
Upgrades AWX-EE from Python 3.9 to Python 3.11. Bringing with it 3.11's speed improvements.
https://docs.python.org/3/whatsnew/3.11.html

This also replaces `python-unversioned-command` with `alternatives` command -- as `python-unversioned-command` always links to `python3.9` in EL9

Working in my local testing:
```
% ansible-builder create -v3 --context context --output-filename Dockerfile
% docker buildx build -f context/Dockerfile -t awx-ee:dev-py311 context --platform linux/amd64
% docker run -it --user=root awx-ee:dev-py311 bash

[root@2d078ce66bc3 runner]# ansible --version
ansible [core 2.15.0]
  config file = None
  configured module search path = ['/root/.ansible/plugins/modules', '/usr/share/ansible/plugins/modules']
  ansible python module location = /usr/local/lib/python3.11/site-packages/ansible
  ansible collection location = /root/.ansible/collections:/usr/share/ansible/collections
  executable location = /usr/local/bin/ansible
  python version = 3.11.2 (main, Feb 16 2023, 00:00:00) [GCC 11.3.1 20221121 (Red Hat 11.3.1-4)] (/usr/bin/python3.11)
  jinja version = 3.1.2
  libyaml = True
```