### PR TITLE
Add `microsoft.ad` collection

### DIFF
--- a/execution-environment.yml
+++ b/execution-environment.yml
@@ -23,6 +23,7 @@ dependencies:
       - name: kubernetes.core
       - name: ansible.posix
       - name: ansible.windows
+      - name: microsoft.ad
       - name: redhatinsights.insights
   system: |
     git-core [platform:rpm]


### PR DESCRIPTION
With the release of `ansible.windows` 2.0.0, many modules have been moved/linked to the `microsoft.ad` collection. This collection should be included in the AWX-EE.

Tested and working in my private EE.

See:
- [ansible.windows changelog](https://github.com/ansible-collections/ansible.windows/blob/main/CHANGELOG.rst#v2-0-0)
- [microsoft.ad GitHub repo](https://github.com/ansible-collections/microsoft.ad)
- [microsoft.ad Galaxy collection](https://galaxy.ansible.com/ui/repo/published/microsoft/ad/)

