### PR TITLE
feat: build images for amd64 and arm64

### DIFF
--- a/.github/workflows/build-latest.yml
+++ b/.github/workflows/build-latest.yml
@@ -14,6 +14,19 @@ jobs:
     runs-on: ubuntu-20.04
     name: Build and push latest tag from devel and on new commits
     steps:
+      - name: Install QEMU static binaries
+        uses: docker/setup-qemu-action@v2
+
+      - name: Configure Buildkit
+        uses: docker/setup-buildx-action@v2
+
+      - name: Authenticate with Quay.io
+        uses: docker/login-action@v2
+        with:
+          registry: quay.io
+          username: ${{ secrets.QUAY_USERNAME }}
+          password: ${{ secrets.QUAY_TOKEN }}
+
       - uses: actions/checkout@v2
 
       - uses: actions/setup-python@v2
@@ -25,13 +38,18 @@ jobs:
           python -m pip install --upgrade pip
           pip install tox
 
-      - name: Build image
-        env:
-          DOCKER_BUILDKIT: 1
+      - name: Create build context for Docker
         run: |
-          tox -e docker -- --tag=quay.io/ansible/awx-ee:latest
+          tox -e docker-create
 
-      - name: Push images
-        run: |
-         echo "${{ secrets.QUAY_TOKEN }}" | docker login quay.io -u ${{ secrets.QUAY_USERNAME }} --password-stdin
-         docker push quay.io/ansible/awx-ee:latest
+      - name: Build and push images
+        uses: docker/build-push-action@v4
+        with:
+          context: context
+          file: context/Dockerfile
+          push: true
+          platforms: |
+            linux/amd64
+            linux/arm64
+          tags: |
+            quay.io/ansible/awx-ee:latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,6 +33,12 @@ jobs:
     runs-on: ubuntu-20.04
     name: Docker
     steps:
+      - name: Install QEMU static binaries
+        uses: docker/setup-qemu-action@v2
+
+      - name: Configure Buildkit
+        uses: docker/setup-buildx-action@v2
+
       - uses: actions/checkout@v2
 
       - uses: actions/setup-python@v2
@@ -44,8 +50,18 @@ jobs:
           python -m pip install --upgrade pip
           pip install tox
 
-      - name: Build EE with Docker
-        env:
-          DOCKER_BUILDKIT: 1
+      - name: Create build context for Docker
         run: |
-          tox -e docker
+          tox -e docker-create
+
+      - name: Build EE with Docker
+        uses: docker/build-push-action@v4
+        with:
+          context: context
+          file: context/Dockerfile
+          push: false
+          platforms: |
+            linux/amd64
+            linux/arm64
+          tags: |
+            quay.io/ansible/awx-ee:latest

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,6 +10,19 @@ jobs:
     runs-on: ubuntu-20.04
     name: Release
     steps:
+      - name: Install QEMU static binaries
+        uses: docker/setup-qemu-action@v2
+
+      - name: Configure Buildkit
+        uses: docker/setup-buildx-action@v2
+
+      - name: Authenticate with Quay.io
+        uses: docker/login-action@v2
+        with:
+          registry: quay.io
+          username: ${{ secrets.QUAY_USERNAME }}
+          password: ${{ secrets.QUAY_TOKEN }}
+
       - uses: actions/checkout@v2
 
       - uses: actions/setup-python@v2
@@ -21,18 +34,19 @@ jobs:
           python -m pip install --upgrade pip
           pip install tox
 
-      - name: Build image
-        env:
-          DOCKER_BUILDKIT: 1
+      - name: Create build context for Docker
         run: |
-          tox -e docker -- --tag=quay.io/ansible/awx-ee:${{ github.event.release.tag_name }}
+          tox -e docker-create
 
-      - name: Apply latest tag
-        run: |
-         docker tag quay.io/ansible/awx-ee:${{ github.event.release.tag_name }} quay.io/ansible/awx-ee:latest
-
-      - name: Push images
-        run: |
-         echo "${{ secrets.QUAY_TOKEN }}" | docker login quay.io -u ${{ secrets.QUAY_USERNAME }} --password-stdin
-         docker push quay.io/ansible/awx-ee:${{ github.event.release.tag_name }}
-         docker push quay.io/ansible/awx-ee:latest
+      - name: Build and push images
+        uses: docker/build-push-action@v4
+        with:
+          context: context
+          file: context/Dockerfile
+          push: true
+          platforms: |
+            linux/amd64
+            linux/arm64
+          tags: |
+            quay.io/ansible/awx-ee:latest
+            quay.io/ansible/awx-ee:${{ steps.image_tag.outputs.tag }}

--- a/tox.ini
+++ b/tox.ini
@@ -24,3 +24,10 @@ allowlist_externals =
 commands =
   /bin/bash -c "docker rmi quay.io/ansible/awx-ee:latest || true"
   ansible-builder build -v3 -t quay.io/ansible/awx-ee {posargs} --container-runtime=docker
+
+[testenv:docker-create]
+passenv = HOME
+allowlist_externals =
+  /bin/bash
+commands =
+  ansible-builder create -v3 --output-filename Dockerfile


### PR DESCRIPTION
We have `receptor's` version for arm64. Let's build `EE` image for arm64 also.
After this change, the Github workflows for https://github.com/ansible/awx may also be changed to support multi-arch `EE` (https://github.com/imjasonh/setup-crane is good candidate for this job).