### PR TITLE
Add ansible.utils

### DIFF
--- a/execution-environment.yml
+++ b/execution-environment.yml
@@ -23,6 +23,7 @@ dependencies:
       - name: kubernetes.core
       - name: ansible.posix
       - name: ansible.windows
+      - name: ansible.utils
       - name: redhatinsights.insights
   system: |
     git-core [platform:rpm]
@@ -51,6 +52,7 @@ dependencies:
     python-daemon
     pyyaml
     six
+    google-cloud-storage
 additional_build_steps:
   append_base:
     - RUN $PYCMD -m pip install -U pip

--- a/execution-environment.yml
+++ b/execution-environment.yml
@@ -52,7 +52,6 @@ dependencies:
     python-daemon
     pyyaml
     six
-    google-cloud-storage
 additional_build_steps:
   append_base:
     - RUN $PYCMD -m pip install -U pip


### PR DESCRIPTION
Adding just the requirements for ansible.utils (Galaxy) and google-cloud-storage (PIP) per the comments here: https://github.com/ansible/awx-ee/pull/92#pullrequestreview-1220048090


Validated this resolves issues with netaddr requirements in AWX, namely:
`Failed to import the required Python library (netaddr) on automation-job's Python /usr/bin/python3.`
