### PR TITLE
add command to pre-create user site directory

### DIFF
--- a/execution-environment.yml
+++ b/execution-environment.yml
@@ -58,3 +58,4 @@ additional_build_steps:
     - COPY --from=quay.io/ansible/receptor:devel /usr/bin/receptor /usr/bin/receptor
     - RUN mkdir -p /var/run/receptor
     - RUN git lfs install --system
+    - RUN mkdir -p $($PYCMD -m site --user-site | sed "s#/root#$(pwd)#")

--- a/execution-environment.yml
+++ b/execution-environment.yml
@@ -58,4 +58,5 @@ additional_build_steps:
     - COPY --from=quay.io/ansible/receptor:devel /usr/bin/receptor /usr/bin/receptor
     - RUN mkdir -p /var/run/receptor
     - RUN git lfs install --system
-    - RUN mkdir -p $($PYCMD -m site --user-site | sed "s#/root#$(pwd)#")
+    - RUN mkdir -p $($PYCMD -m site --user-site | sed "s|$HOME|$(pwd)|")
+    - RUN chmod -R ug+rwx $(python -m site --user-site | sed "s|$HOME|$(pwd)|" | cut -d '/' -f1,2,3)

--- a/execution-environment.yml
+++ b/execution-environment.yml
@@ -59,4 +59,4 @@ additional_build_steps:
     - RUN mkdir -p /var/run/receptor
     - RUN git lfs install --system
     - RUN mkdir -p $($PYCMD -m site --user-site | sed "s|$HOME|$(pwd)|")
-    - RUN chmod -R ug+rwx $(python -m site --user-site | sed "s|$HOME|$(pwd)|" | cut -d '/' -f1,2,3)
+    - RUN chmod -R ug+rwx $($PYCMD -m site --user-site | sed "s|$HOME|$(pwd)|" | cut -d '/' -f1,2,3)


### PR DESCRIPTION
This was the most elegant way I could think of to resolve #220.

This will create a directory at `WORKDIR/.local/lib/python3.9/site-packages`. With the default WORKDIR, it would be `/runner/.local/lib/python3.9/site-packages`. Which once python is launched under the runner user, the new path is included in the python paths. Then if a python module is installed during a playbook to that path, it is accessible by both modules and lookups.