### PR TITLE
Add podman symbolic link

### DIFF
--- a/execution-environment.yml
+++ b/execution-environment.yml
@@ -58,3 +58,4 @@ additional_build_steps:
     - COPY --from=quay.io/ansible/receptor:devel /usr/bin/receptor /usr/bin/receptor
     - RUN mkdir -p /var/run/receptor
     - RUN git lfs install --system
+    - RUN ln -s /usr/bin/podman-remote /usr/bin/podman


### PR DESCRIPTION
Map `podman` to `podman-remote` via symbolic link to allow `podman` to run AAP jobs via receptor