### PR TITLE
Update execution-environment.yml to add kubevirt.core

### DIFF
--- a/execution-environment.yml
+++ b/execution-environment.yml
@@ -25,6 +25,7 @@ dependencies:
       - name: ansible.posix
       - name: ansible.windows
       - name: redhatinsights.insights
+      - name: kubevirt.core
   system: |
     git-core [platform:rpm]
     python3.9-devel [platform:rpm compile]


### PR DESCRIPTION
In order to have openshift virtualization as a inventory source we need the kubevirt.core collection added to this collection