### PR TITLE
Include 'community.general' module in execution environment.

### DIFF
--- a/execution-environment.yml
+++ b/execution-environment.yml
@@ -19,6 +19,7 @@ dependencies:
       - name: theforeman.foreman
       - name: google.cloud
       - name: openstack.cloud
+      - name: community.general
       - name: community.vmware
       - name: ovirt.ovirt
       - name: kubernetes.core


### PR DESCRIPTION
The general community package should probably be included by default.

I did try to find if there's a reason it's not been included yet, but I can't.