### PR TITLE
Switch to `centos:stream9-minimal`

### DIFF
--- a/execution-environment.yml
+++ b/execution-environment.yml
@@ -2,7 +2,9 @@
 version: 3
 images:
   base_image:
-    name: quay.io/centos/centos:stream9
+    name: quay.io/centos/centos:stream9-minimal
+options:
+  package_manager_path: /usr/bin/microdnf
 dependencies:
   python_interpreter:
     package_system: python3.11
@@ -32,11 +34,10 @@ dependencies:
   system: |
     git-core [platform:rpm]
     python3.11-devel [platform:rpm compile]
+    python3.11-rpm [platform:rpm epel]
     libcurl-devel [platform:rpm compile]
     krb5-devel [platform:rpm compile]
     krb5-workstation [platform:rpm]
-    subversion [platform:rpm]
-    subversion [platform:dpkg]
     git-lfs [platform:rpm]
     sshpass [platform:rpm]
     rsync [platform:rpm]
@@ -62,6 +63,11 @@ dependencies:
     pyyaml
     six
     receptorctl
+  exclude:
+    system:
+      - python3
+      - python3-devel
+      - python3-rpm
 additional_build_steps:
   append_base:
     - RUN $PYCMD -m pip install -U pip
@@ -69,5 +75,7 @@ additional_build_steps:
     - COPY --from=quay.io/ansible/receptor:devel /usr/bin/receptor /usr/bin/receptor
     - RUN mkdir -p /var/run/receptor
     - RUN git lfs install --system
-    # SymLink `python` -> `python3.11`
-    - RUN alternatives --install /usr/bin/python python /usr/bin/python3.11 311
+    - >-
+      RUN alternatives --install /usr/bin/python3 python3 /usr/bin/python3.11 1
+      && alternatives --install /usr/bin/python python /usr/bin/python3.11 1
+      && alternatives --install /usr/bin/pip3 pip3 /usr/bin/pip3.11 1


### PR DESCRIPTION
This PR switches the base image to `centos:stream9-minimal` which uses `microdnf` and does not bundle Python3.9, allowing us to ship a final image without Python 3.9 installed at all.

Also removes `subversion`, as it hard-depends upon `python3.9`, no love lost.

~~This is another take on https://github.com/ansible/awx-ee/pull/207 and https://github.com/ansible/awx-ee/pull/244~~
EDIT: Rebased after https://github.com/ansible/awx-ee/pull/207 was merged.

---

> Currently this PR relies upon https://github.com/ansible/ansible-builder/pull/664 which enables dependency exclusions, allowing overrides of `bindep.txt` dependencies directly inherited from collections.
> 
> ~~This PR will be marked as a Draft until https://github.com/ansible/ansible-builder/pull/664 is merged.~~

EDIT: https://github.com/ansible/ansible-builder/pull/664 has been merged. This PR is ready for review.