### PR TITLE
update-crypto-policies sha1

### DIFF
--- a/execution-environment.yml
+++ b/execution-environment.yml
@@ -66,4 +66,5 @@ additional_build_steps:
   append_final:
     - COPY --from=quay.io/ansible/receptor:devel /usr/bin/receptor /usr/bin/receptor
     - RUN mkdir -p /var/run/receptor
+    - RUN update-crypto-policies --set DEFAULT:SHA1
     - RUN git lfs install --system


### PR DESCRIPTION
Adds support for SHA1 Crypto Policies to provide support for older SSH Keys.

More details at https://github.com/ansible/awx/issues/15181#issuecomment-2148154447