### PR TITLE
Symlink pip3 to pip3.11

### DIFF
--- a/execution-environment.yml
+++ b/execution-environment.yml
@@ -69,5 +69,8 @@ additional_build_steps:
     - COPY --from=quay.io/ansible/receptor:devel /usr/bin/receptor /usr/bin/receptor
     - RUN mkdir -p /var/run/receptor
     - RUN git lfs install --system
-    # SymLink `python` -> `python3.11`
-    - RUN alternatives --install /usr/bin/python python /usr/bin/python3.11 311
+    # SymLink `python` -> `python3.11` and `python3` -> `python3.11` and `pip3` -> `pip3.11`
+    - >-
+      RUN alternatives --install /usr/bin/python3 python3 /usr/bin/python3.11 1
+      && alternatives --install /usr/bin/python python /usr/bin/python3.11 1
+      && alternatives --install /usr/bin/pip3 pip3 /usr/bin/pip3.11 1


### PR DESCRIPTION
Currently only python is mapped to 3.11 but not pip3 and python3.

Those two are mapped to the default system python version, which is python 3.9

Fixes: #255 