### PR TITLE
Fix a crash: type 'NoneType' is not an acceptable base type

### DIFF
--- a/execution-environment.yml
+++ b/execution-environment.yml
@@ -15,6 +15,7 @@ dependencies:
   galaxy: |
     ---
     collections:
+      - name: community.general
       - name: awx.awx
       - name: azure.azcollection
         version: ">=2.1.0"
@@ -65,6 +66,7 @@ dependencies:
 additional_build_steps:
   append_base:
     - RUN $PYCMD -m pip install -U pip
+    - ENV ANSIBLE_STDOUT_CALLBACK=ansible.builtin.default
   append_final:
     - COPY --from=quay.io/ansible/receptor:devel /usr/bin/receptor /usr/bin/receptor
     - RUN mkdir -p /var/run/receptor


### PR DESCRIPTION
I was getting a crash when I tried to run awx-ee using ansible-navigator:

```
Traceback (most recent call last):
  File "/usr/local/lib/python3.11/site-packages/ansible/cli/__init__.py", line 646, in cli_executor
    exit_code = cli.run()
                ^^^^^^^^^
  File "/usr/local/lib/python3.11/site-packages/ansible/cli/playbook.py", line 155, in run
    results = pbex.run()
              ^^^^^^^^^^
  File "/usr/local/lib/python3.11/site-packages/ansible/executor/playbook_executor.py", line 117, in run
    self._tqm.load_callbacks()
  File "/usr/local/lib/python3.11/site-packages/ansible/executor/task_queue_manager.py", line 198, in load_callbacks
    self._stdout_callback = callback_loader.get(self._stdout_callback)
                            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/site-packages/ansible/plugins/loader.py", line 861, in get
    return self.get_with_context(name, *args, **kwargs).object
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/site-packages/ansible/plugins/loader.py", line 907, in get_with_context
    self._module_cache[path] = self._load_module_source(resolved_type_name, path)
                               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/site-packages/ansible/plugins/loader.py", line 834, in _load_module_source
    spec.loader.exec_module(module)
  File "<frozen importlib._bootstrap_external>", line 940, in exec_module
  File "<frozen importlib._bootstrap>", line 241, in _call_with_frames_removed
  File "/runner/artifacts/5c4373ae-294c-4355-9717-91217391340d/callback/awx_display.py", line 317, in <module>
    class CallbackModule(DefaultCallbackModule):
TypeError: type 'NoneType' is not an acceptable base type
```

According to https://github.com/ansible/ansible-runner/issues/1346 it might be caused by the yaml output callback so this commit sets an environment variable to set the callback to the default. It also installs the community.general collection.