### PR TITLE
Use the IMAGE_REGISTRY env var

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,6 +26,8 @@ jobs:
           pip install tox
 
       - name: Build EE with Podman
+        env:
+          IMAGE_REGISTRY: ${{ vars.IMAGE_REGISTRY }}
         run: |
           tox -e podman
 
@@ -47,5 +49,6 @@ jobs:
       - name: Build EE with Docker
         env:
           DOCKER_BUILDKIT: 1
+          IMAGE_REGISTRY: ${{ vars.IMAGE_REGISTRY }}
         run: |
           tox -e docker

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,15 +24,16 @@ jobs:
       - name: Build image
         env:
           DOCKER_BUILDKIT: 1
+          IMAGE_REGISTRY: ${{ vars.IMAGE_REGISTRY }}
         run: |
-          tox -e docker -- --tag=quay.io/ansible/awx-ee:${{ github.event.release.tag_name }}
+          tox -e docker -- --tag=${{ vars.IMAGE_REGISTRY }}/awx-ee:${{ github.event.release.tag_name }}
 
       - name: Apply latest tag
         run: |
-         docker tag quay.io/ansible/awx-ee:${{ github.event.release.tag_name }} quay.io/ansible/awx-ee:latest
+         docker tag ${{ vars.IMAGE_REGISTRY }}/awx-ee:${{ github.event.release.tag_name }} ${{ vars.IMAGE_REGISTRY }}/awx-ee:latest
 
       - name: Push images
         run: |
          echo "${{ secrets.QUAY_TOKEN }}" | docker login quay.io -u ${{ secrets.QUAY_USERNAME }} --password-stdin
-         docker push quay.io/ansible/awx-ee:${{ github.event.release.tag_name }}
-         docker push quay.io/ansible/awx-ee:latest
+         docker push ${{ vars.IMAGE_REGISTRY }}/awx-ee:${{ github.event.release.tag_name }}
+         docker push ${{ vars.IMAGE_REGISTRY }}/awx-ee:latest

--- a/tox.ini
+++ b/tox.ini
@@ -13,8 +13,8 @@ allowlist_externals =
   /bin/bash
   podman
 commands =
-  /bin/bash -c "podman rmi quay.io/ansible/awx-ee:latest || true"
-  ansible-builder build -v3 -t quay.io/ansible/awx-ee {posargs}
+  /bin/bash -c "podman rmi {env:IMAGE_REGISTRY}/awx-ee:latest || true"
+  ansible-builder build -v3 -t {env:IMAGE_REGISTRY}/awx-ee {posargs}
 
 [testenv:docker]
 passenv = HOME,DOCKER_BUILDKIT
@@ -22,5 +22,5 @@ allowlist_externals =
   /bin/bash
   docker
 commands =
-  /bin/bash -c "docker rmi quay.io/ansible/awx-ee:latest || true"
-  ansible-builder build -v3 -t quay.io/ansible/awx-ee {posargs} --container-runtime=docker
+  /bin/bash -c "docker rmi {env:IMAGE_REGISTRY}/awx-ee:latest || true"
+  ansible-builder build -v3 -t {env:IMAGE_REGISTRY}/awx-ee {posargs} --container-runtime=docker


### PR DESCRIPTION
It's set, but most places used a hard-coded string instead of the variable value. I might have to maintain a fork so I'd like to have this parameterized, and since IMAGE_REGISTRY is already set we might as well use it.