### PR TITLE
Add packaging dependency for indirect node counting

### DIFF
--- a/execution-environment.yml
+++ b/execution-environment.yml
@@ -61,6 +61,7 @@ dependencies:
     python-daemon
     pyyaml
     six
+    packaging
     receptorctl
 additional_build_steps:
   append_base:


### PR DESCRIPTION
## Summary

Add `packaging` to the EE's Python dependencies.

The `indirect_instance_count` callback plugin (which runs inside the EE) imports `packaging.version` for semantic version comparison in the external query version fallback logic (AAP-58452). Without this dependency, the callback plugin fails to load, breaking all indirect node counting — including the existing embedded query path.

Related: ansible/awx#16312