### PR TITLE
Pin to older ansible-core version

### DIFF
--- a/execution-environment.yml
+++ b/execution-environment.yml
@@ -8,7 +8,7 @@ dependencies:
     package_system: python3.12
     python_path: /usr/bin/python3.12
   ansible_core:
-    package_pip: ansible-core>=2.20.3,<2.21
+    package_pip: ansible-core<2.19
   ansible_runner:
     package_pip: ansible-runner
   galaxy: |


### PR DESCRIPTION
The 2.19 version breaks AWX CI with no immediate fix obvious. We only want this to be temporary, pending solution of the Ansible facts issue.